### PR TITLE
feat: publish Docker images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.next
+.vinext
+.wrangler
+dist
+node_modules
+npm-debug.log*
+.env*
+coverage
+outputs
+work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,50 @@ jobs:
 
       - name: Build and test
         run: npm test
+
+  publish-image:
+    name: Publish Docker image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-bookworm-slim AS runner
+
+ENV NODE_ENV=production \
+    WRANGLER_LOG_PATH=/tmp/wrangler.log \
+    WRANGLER_SEND_METRICS=false
+
+WORKDIR /app
+
+RUN npm install --global wrangler@4.92.0 \
+    && npm cache clean --force \
+    && mkdir -p /data \
+    && chown node:node /app /data
+
+COPY --from=builder --chown=node:node /app/dist ./dist
+
+USER node
+
+EXPOSE 3000
+VOLUME ["/data"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:3000/api/books').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));"]
+
+CMD ["wrangler", "dev", "--config", "/app/dist/server/wrangler.json", "--local", "--persist-to", "/data", "--ip", "0.0.0.0", "--port", "3000", "--show-interactive-dev-session=false"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,37 @@ on the same network.
 Provider credentials are configured in the application. Translation results,
 uploaded books, and page indexes are not stored in browser caches.
 
+## Docker Deployment
+
+Images for `linux/amd64` and `linux/arm64` are published from the `main` branch
+to `ghcr.io/mrcroxx/verso`. Start the latest image with Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+Then open `http://localhost:3000`. The named `verso-data` volume stores the D1
+database and R2 objects used for uploaded books, page indexes, and translations.
+Back up this volume before replacing or moving the deployment.
+
+The equivalent Docker command is:
+
+```bash
+docker run -d \
+  --name verso \
+  --restart unless-stopped \
+  -p 3000:3000 \
+  -v verso-data:/data \
+  ghcr.io/mrcroxx/verso:latest
+```
+
+To update an existing Compose deployment:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
 ## Validation
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  verso:
+    image: ghcr.io/mrcroxx/verso:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - verso-data:/data
+    restart: unless-stopped
+
+volumes:
+  verso-data:


### PR DESCRIPTION
## Summary

- add a multi-stage, non-root Docker image for the existing Cloudflare Worker runtime
- persist local D1 and R2 state under `/data` and provide a ready-to-run Compose deployment
- publish `linux/amd64` and `linux/arm64` images to GHCR after `main` validation succeeds
- document deployment, persistence, and upgrades

## Why

Verso currently requires a source checkout and local Node.js toolchain. Publishing a self-contained image lets users deploy the application directly while preserving server-side storage for books, indexes, and translations.

## Validation

- `npm run lint`
- `npm test` (24 tests)
- `docker build --tag verso:local .`
- `docker compose config --quiet`
- container health check and `GET /api/books`