### PR TITLE
fix: install CA certificates in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-RUN npm install --global wrangler@4.92.0 \
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install --global wrangler@4.92.0 \
     && npm cache clean --force \
     && mkdir -p /data \
     && chown node:node /app /data


### PR DESCRIPTION
## Summary

- install the system CA certificate bundle in the production Docker image
- remove apt package metadata after installation to keep the runtime layer lean

## Root cause

The `node:22-bookworm-slim` runtime image did not contain `/etc/ssl/certs/ca-certificates.crt`. Node requests could still use Node's bundled trust store, but Wrangler/Workerd outbound HTTPS requests depend on the system CA bundle. As a result, translation requests to valid HTTPS providers failed with `unable to get local issuer certificate` and surfaced as internal errors.

## Impact

Locally deployed Docker containers can now make HTTPS requests to OpenAI-compatible translation providers without disabling certificate verification or requiring host networking.

## Validation

- `npm run lint`
- `npm test` (24 tests passed)
- built and ran the production Docker image
- verified an outbound translation request reached the configured provider and returned the provider's expected `401 Unauthorized` for an intentionally invalid test key, with no TLS certificate error